### PR TITLE
Fixes for CronJob

### DIFF
--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -38,7 +38,7 @@ class aide::cron (
     } else {
       cron::job { 'aide':
         ensure  => $cron_ensure,
-        command => "${settings} | ${mail_path} -s ${email_subject}",
+        command => "${settings} | ${cat_path} -v | ${mail_path} -s ${email_subject}",
         user    => 'root',
         hour    => $hour,
         minute  => $minute,

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -9,6 +9,7 @@ class aide::cron (
   $aide_path,
   $cat_path,
   $rm_path,
+  $mail_path,
   $conf_path,
   $minute,
   $hour,
@@ -29,7 +30,7 @@ class aide::cron (
     if $mail_only_on_changes {
       cron::job { 'aide' :
         ensure  => $cron_ensure,
-        command => "LOG=$(mktemp) && ${settings} > \$LOG 2>&1 || ${cat_path} -v \$LOG | mail -E -s ${email_subject}; ${rm_path} -f \$LOG",
+        command => "LOG=$(mktemp) && ${settings} > \$LOG 2>&1 || ${cat_path} -v \$LOG | ${mail_path} -E -s ${email_subject}; ${rm_path} -f \$LOG",
         user    => 'root',
         hour    => $hour,
         minute  => $minute,
@@ -37,7 +38,7 @@ class aide::cron (
     } else {
       cron::job { 'aide':
         ensure  => $cron_ensure,
-        command => "${settings} | mail -s ${email_subject}",
+        command => "${settings} | ${mail_path} -s ${email_subject}",
         user    => 'root',
         hour    => $hour,
         minute  => $minute,

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -30,7 +30,7 @@ class aide::cron (
     if $mail_only_on_changes {
       cron::job { 'aide' :
         ensure  => $cron_ensure,
-        command => "LOG=$(mktemp) && ${settings} > \$LOG 2>&1 || ${cat_path} -v \$LOG | ${mail_path} -E -s ${email_subject}; ${rm_path} -f \$LOG",
+        command => "AIDE_OUT=$(${settings} 2>&1) || echo \"\${AIDE_OUT}\" | ${cat_path} -v | ${mail_path} -E -s ${email_subject}",
         user    => 'root',
         hour    => $hour,
         minute  => $minute,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,7 @@ class aide (
       aide_path            => $aide_path,
       cat_path             => $aide::params::cat_path,
       rm_path              => $aide::params::rm_path,
+      mail_path            => $aide::params::mail_path,
       minute               => $minute,
       hour                 => $hour,
       nocheck              => $nocheck,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,18 +29,21 @@ class aide::params {
       $aide_path = '/usr/bin/aide'
       $cat_path  = '/bin/cat'
       $rm_path   = '/bin/rm'
+      $mail_path = '/usr/bin/mail'
       $conf_path = '/etc/aide/aide.conf'
     }
     'Redhat': {
       $aide_path = '/usr/sbin/aide'
       $cat_path  = '/usr/bin/cat'
       $rm_path   = '/usr/bin/rm'
+      $mail_path = '/usr/bin/mail'
       $conf_path = '/etc/aide.conf'
     }
     default: {
       $aide_path = '/usr/sbin/aide'
       $cat_path  = '/usr/bin/cat'
       $rm_path   = '/usr/bin/rm'
+      $mail_path = '/usr/bin/mail'
       $conf_path = '/etc/aide.conf'
       #fail("The ${module_name} module is not supported on an ${::osfamily} based system.")
     }


### PR DESCRIPTION
Since the module has been migrated to use `cron::job` instead of `cron`, the shell redirection was broken - also, the path for the mail program got lost. 

This PR fixes the following issues:
- Shell redirection not working in `/etc/cron.d/` used by `cron::job`, which effectively broke `mail_only_on_changes`. This is fixed by dropping the temporary file and just storing AIDE output in a shell variable, which also improves the cronjob, since the temporary file is gotten rid of. 
- Adds `cat -v` to the non-`mail_only_on_changes` branch, which is needed to escape e.g. filenames with non-printable characters. 
- Adds the path back to the `mail` program. 