### PR TITLE
cron, firstrun: Wrap aide in nice + ionice.

### DIFF
--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -30,7 +30,7 @@ class aide::cron (
     if $mail_only_on_changes {
       cron::job { 'aide' :
         ensure  => $cron_ensure,
-        command => "AIDE_OUT=$(${settings} 2>&1) || echo \"\${AIDE_OUT}\" | ${cat_path} -v | ${mail_path} -E -s ${email_subject}",
+        command => "AIDE_OUT=$(nice ionice -c3 ${settings} 2>&1) || echo \"\${AIDE_OUT}\" | ${cat_path} -v | ${mail_path} -E -s ${email_subject}",
         user    => 'root',
         hour    => $hour,
         minute  => $minute,
@@ -38,7 +38,7 @@ class aide::cron (
     } else {
       cron::job { 'aide':
         ensure  => $cron_ensure,
-        command => "${settings} | ${cat_path} -v | ${mail_path} -s ${email_subject}",
+        command => "nice ionice -c3 ${settings} | ${cat_path} -v | ${mail_path} -s ${email_subject}",
         user    => 'root',
         hour    => $hour,
         minute  => $minute,
@@ -47,7 +47,7 @@ class aide::cron (
   } else {
     cron::job { 'aide':
       ensure  => $cron_ensure,
-      command => "${aide_path} --config ${conf_path} --check",
+      command => "nice ionice -c3 ${aide_path} --config ${conf_path} --check",
       user    => 'root',
       hour    => $hour,
       minute  => $minute,

--- a/manifests/firstrun.pp
+++ b/manifests/firstrun.pp
@@ -14,7 +14,7 @@ class aide::firstrun (
 ) {
 
   exec { 'aide init':
-    command     => "${aide_path} --init --config ${conf_path}",
+    command     => "nice ionice -c3 ${aide_path} --init --config ${conf_path}",
     user        => 'root',
     timeout     => $init_timeout,
     refreshonly => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,6 +77,11 @@ class aide (
   $init_timeout         = $aide::params::init_timeout,
 ) inherits aide::params {
 
+  # Used to throttle I/O and CPU load of AIDE.
+  package { 'util-linux':
+    ensure => 'present',
+  }
+
   package { $package:
     ensure => $version,
   }


### PR DESCRIPTION
This reduces heavy I/O phases which may affect
the actual services running on the machine.

We noticed this especially when many machines are running AIDE every few hours and I/O is limited (e.g. in VMs), leading to NTP shifting away, or the services on the machine becoming slow temporarily. 
`util-linux` is the name of the package containing `nice` and `ionice` in Debian + Ubuntu + CentOS (and in most cases, is anyways already present on the system). 