### PR TITLE
aide::config: Add report_ignore_e2fsattrs config parameter.

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -7,6 +7,7 @@ aide::db_temp_path: '/var/lib/aide/aide.db.new'
 aide::gzip_dbout: 'no'
 aide::aide_log: '/var/log/aide/aide.log'
 aide::syslogout: true
+aide::report_ignore_e2fsattrs: ~
 aide::hour: 0
 aide::minute: 0
 aide::nocheck: false

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,6 +12,7 @@ class aide::config (
   $gzip_dbout,
   $aide_log,
   $syslogout,
+  $report_ignore_e2fsattrs,
   $config_template,
 ) {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,14 @@
 #   Allows to adjust timeout of the "aide --init" run.
 #   Puppet default exec timeout is 300 (which is also kept),
 #   but this may be insufficient for more complex aide DBs.
+#
+# @report_ignore_e2fsattrs
+#   List (no delimiter) of ext2 file attributes which are
+#   to be ignored in the final report.
+#   See chattr(1) for the available attributes.
+#   Use '0' to not ignore any attribute.
+#   Ignored attributes are represented by a ':' in the output.
+#   The default is to not ignore any ext2 file attribute.
 
 class aide (
   $package,
@@ -75,6 +83,7 @@ class aide (
   $mailto,
   $mail_only_on_changes,
   $init_timeout,
+  $report_ignore_e2fsattrs,
   $cat_path,
   $rm_path,
   $mail_path,
@@ -104,14 +113,15 @@ class aide (
     }
 
   -> class { '::aide::config':
-    conf_path       => $conf_path,
-    db_path         => $db_path,
-    db_temp_path    => $db_temp_path,
-    gzip_dbout      => $gzip_dbout,
-    aide_log        => $aide_log,
-    syslogout       => $syslogout,
-    config_template => $config_template,
-    require         => Package[$package],
+    conf_path               => $conf_path,
+    db_path                 => $db_path,
+    db_temp_path            => $db_temp_path,
+    gzip_dbout              => $gzip_dbout,
+    aide_log                => $aide_log,
+    syslogout               => $syslogout,
+    report_ignore_e2fsattrs => $report_ignore_e2fsattrs,
+    config_template         => $config_template,
+    require                 => Package[$package],
   }
 
   ~> class  { '::aide::firstrun':

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -6,13 +6,14 @@ describe 'aide::config' do
       let(:facts) { os_facts }
       let(:params) do
         {
-          'conf_path'       => '/etc/aide/aide.conf',
-          'db_path'         => '/var/lib/aide/aide.db',
-          'db_temp_path'    => '/var/lib/aide/aide.db.new',
-          'gzip_dbout'      => 'no',
-          'aide_log'        => '/var/log/aide/aide.log',
-          'syslogout'       => true,
-          'config_template' => 'aide/aide.conf.erb',
+          'conf_path'               => '/etc/aide/aide.conf',
+          'db_path'                 => '/var/lib/aide/aide.db',
+          'db_temp_path'            => '/var/lib/aide/aide.db.new',
+          'gzip_dbout'              => 'no',
+          'aide_log'                => '/var/log/aide/aide.log',
+          'syslogout'               => true,
+          'report_ignore_e2fsattrs' => :undef,
+          'config_template'         => 'aide/aide.conf.erb',
         }
       end
 

--- a/templates/aide.conf.erb
+++ b/templates/aide.conf.erb
@@ -21,6 +21,11 @@ report_url=file://<%= @aide_log %>
 report_url=syslog:LOG_AUTH
 <% end -%>
 
+# Global report_ignore settings
+<% if @report_ignore_e2fsattrs -%>
+report_ignore_e2fsattrs=<%= @report_ignore_e2fsattrs %>
+<% end -%>
+
 # Rule predefined types:
 #p:      permissions
 #i:      inode:


### PR DESCRIPTION
This allows to ignore selected ext2 file attributes in the
final report. Unset by default.
Very useful to ignore e.g. I (indexed directory)
which on some systems gets flipped automatically
if the number of files in a directory is increased
(example: Log file directories due to rotation).

For more details, see for example this upstream discussion:
https://github.com/aide/aide/issues/47
which considers to ignore e2fsattrs which can not be set or removed. 