### PR TITLE
Add day, month and day of week option to cron job.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Include the aide class and set cron run time to 6am with mail to a user other th
     class { 'aide':
       minute => 0,
       hour   => 6,
+      day    => 3,
     }
 
 Watch permissions of all files on filesystem
@@ -118,7 +119,7 @@ This will watch only the file /var/log/messages.  It will ignore /var/log/messag
 
 ## Cron
 
-A cron job is created during installation to run aide checks that use the `hour` and `minute` parameters to specify the run time.
+A cron job is created during installation to run aide checks that use the `minute`, `hour`, `day`, `month` and `weekday` parameters to specify the run time.
 
 This cron job can be disabled by setting the `aide::nocheck` parameter.
 
@@ -230,7 +231,7 @@ Default value: `true`.
 
 #### `minute`
 
-Data type: Integer.
+Data type: Cron::Minute (Integer)
 
 Minute of cron job to run
 
@@ -238,11 +239,35 @@ Default value: `0`.
 
 #### `hour`
 
-Data type: Integer.
+Data type: Cron::Hour (Integer).
 
 Hour of cron job to run
 
 Default value: `0`.
+
+#### `date`
+
+Data type: Cron::Date (Integer).
+
+Date of cron job to run
+
+Default value: `*`.
+
+#### `month`
+
+Data type: Cron::Month (Integer).
+
+Month of cron job to run
+
+Default value: `*`.
+
+#### `weekday`
+
+Data type: Cron::Weekday (Integer).
+
+Day of week of cron job to run
+
+Default value: `*`.
 
 #### `nocheck`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -8,8 +8,6 @@ aide::gzip_dbout: false
 aide::aide_log: '/var/log/aide/aide.log'
 aide::syslogout: true
 aide::report_ignore_e2fsattrs: ~
-aide::hour: 0
-aide::minute: 0
 aide::nocheck: false
 aide::mailto: ~
 aide::mail_only_on_changes: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,15 @@
 #@param minute
 #   Minute of cron job to run.
 #
+#@param date
+#   Date of cron job to run.
+#
+#@param month
+#   Month of cron job to run.
+#
+#@param weekday
+#   Day of week of cron job to run.
+#
 #@param nocheck
 #   Whether to enable or disable scheduled checks.
 #
@@ -82,8 +91,11 @@ class aide (
   Optional[String] $report_ignore_e2fsattrs,
   String $aide_log,
   Boolean $syslogout,
-  Integer $minute,
-  Integer $hour,
+  Cron::Minute        $minute      = '0',
+  Cron::Hour          $hour        = '0',
+  Cron::Date          $date        = '*',
+  Cron::Month         $month       = '*',
+  Cron::Weekday       $weekday     = '*',
   Boolean $nocheck,
   Optional[String] $mailto,
   Boolean $mail_only_on_changes,
@@ -107,6 +119,9 @@ class aide (
     mail_path            => $mail_path,
     minute               => $minute,
     hour                 => $hour,
+    date                 => $date,
+    month                => $month,
+    weekday              => $weekday,
     nocheck              => $nocheck,
     mailto               => $mailto,
     mail_only_on_changes => $mail_only_on_changes,


### PR DESCRIPTION
Added day of month, month and day of week options to the AIDE cron job.  In my environment, running the AIDE job every day was taxing my servers too much.  Once a week or once a month is sufficient for my purposes.

Also, I simplified the cron.pp manifest a bit since all that logic was just to build the command variable for the cron job.

I have *no idea* how to update spec tests and am trying to learn how to do so.  If someone can help add spec tests, I would be most appreciative.