### PR TITLE
aide::cron: Add max_mail_lines feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,14 @@ Whether to only send emails when changes are detected.
 
 Default value: `false`
 
+#### `max_mail_lines`
+
+Data type: Optional[Integer[1]]
+
+If set to a positive integer, mail messages are truncated to the given number of lines. This can be used to prevent too large mail bodies for large changesets (which may be triggered by OS updates, and not be accepted by the mail server).
+
+Default value: `undef`
+
 #### `init_timeout`
 
 Data type: Integer.
@@ -334,6 +342,14 @@ Data type: String.
 The rm command path. This is based on the system
 
 Default value: `/usr/bin/rm`
+
+### `head_path`
+
+Data type: String.
+
+The head command path. This is based on the system
+
+Default value: `/usr/bin/head`
 
 
 ## Hiera

--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,5 +1,6 @@
 aide::aide_path: '/usr/bin/aide'
 aide::cat_path: '/bin/cat'
 aide::rm_path: '/bin/rm'
+aide::head_path: '/bin/head'
 aide::mail_path: '/usr/bin/mail'
 aide::conf_path: '/etc/aide/aide.conf'

--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -1,5 +1,6 @@
 aide::aide_path: '/usr/sbin/aide'
 aide::cat_path: '/usr/bin/cat'
 aide::rm_path: '/usr/bin/rm'
+aide::head_path: '/usr/bin/head'
 aide::mail_path: '/usr/bin/mail'
 aide::conf_path: '/etc/aide.conf'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -11,11 +11,13 @@ aide::report_ignore_e2fsattrs: ~
 aide::nocheck: false
 aide::mailto: ~
 aide::mail_only_on_changes: false
+aide::max_mail_lines: ~
 aide::config_template: 'aide/aide.conf.erb'
 aide::cron_template: 'aide/cron.erb'
 aide::init_timeout: 300
 aide::aide_path: '/usr/sbin/aide'
 aide::cat_path: '/usr/bin/cat'
 aide::rm_path: '/usr/bin/rm'
+aide::head_path: '/usr/bin/head'
 aide::mail_path: '/usr/bin/mail'
 aide::conf_path: '/etc/aide.conf'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,10 @@
 #   mails are only sent if changes are detected by AIDE.
 #   By default this flag is set to false
 #
+#@param max_mail_lines
+#   Undef by default. If set, mail output is capped to the first
+#   max_mail_lines number of lines (to prevent too large mail bodies).
+#
 #@param init_timeout
 #   Allows to adjust timeout of the "aide --init" run.
 #   Puppet default exec timeout is 300 (which is also kept),
@@ -80,6 +84,7 @@
 #   The default is to not ignore any ext2 file attribute.
 #@param cat_path is the system cat command path.
 #@param rm_path is the system rm command path.
+#@param head_path is the system head command path.
 #@param aide_path is the aide path
 #@param mail_path is the aide path
 class aide (
@@ -98,9 +103,11 @@ class aide (
   Boolean $nocheck,
   Optional[String] $mailto,
   Boolean $mail_only_on_changes,
+  Optional[Integer[1]] $max_mail_lines,
   Integer $init_timeout,
   String $cat_path,
   String $rm_path,
+  String $head_path,
   Cron::Minute        $minute      = '0',
   Cron::Hour          $hour        = '0',
   Cron::Date          $date        = '*',
@@ -121,6 +128,7 @@ class aide (
     aide_path               => $aide_path,
     cat_path                => $cat_path,
     rm_path                 => $rm_path,
+    head_path               => $head_path,
     mail_path               => $mail_path,
     minute                  => $minute,
     hour                    => $hour,
@@ -131,6 +139,7 @@ class aide (
     nocheck                 => $nocheck,
     mailto                  => $mailto,
     mail_only_on_changes    => $mail_only_on_changes,
+    max_mail_lines          => $max_mail_lines,
     conf_path               => $conf_path,
     require                 => Package[$package],
   }

--- a/spec/classes/cron_spec.rb
+++ b/spec/classes/cron_spec.rb
@@ -13,6 +13,7 @@ describe 'aide::cron' do
           'aide_path'            => '/usr/bin/aide',
           'cat_path'             => '/bin/cat',
           'rm_path'              => '/bin/rm',
+          'head_path'            => '/bin/head',
           'mail_path'            => '/usr/bin/mail',
           'conf_path'            => '/etc/aide/aide.conf',
           'minute'               => 0,
@@ -23,6 +24,7 @@ describe 'aide::cron' do
           'nocheck'              => false,
           'mailto'               => 'aide@edu',
           'mail_only_on_changes' => false,
+          'max_mail_lines'       => 1000,
         }
       end
 


### PR DESCRIPTION
This allows to limit the maximum number of lines sent in change mails before the mail is truncated. By default, no truncation happens.

This functionality is useful to prevent too large mails when OS updates happen, which may be bounced by mail servers otherwise.