### PR TITLE
Increased Puppet version supported to 7 & 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
-## Release 2.2.1
+## Release 3.0.0
 
-**Enahncements**
+**Enhancements**
 
 * Merge pull request to update metadata dependencies (canihavethisone)
 * Update changelog and metadata
+
+** Breaking Changes **
+* Drop Puppet 6 and earlier support, add Puppet 7 & 8
 
 ## Release 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 
 * Merge pull request to update metadata dependencies (canihavethisone)
 * Update changelog and metadata
+* Add Puppet 8 support
 
 **Breaking Changes**
-* Drop Puppet 6 and earlier support, add Puppet 8
+* Drop Puppet 6 and earlier support
 
 ## Release 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Merge pull request to update metadata dependencies (canihavethisone)
 * Update changelog and metadata
 
-** Breaking Changes **
+**Breaking Changes**
 * Drop Puppet 6 and earlier support, add Puppet 7 & 8
 
 ## Release 2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 **Enhancements**
 
-* Merge pull request to update metadata dependencies (canihavethisone)
+* Update dependencies to allow puppetlabs/stdlib 9.x (canihavethisone)
+* Add Puppet 8 support (canihavethisone)
 * Update changelog and metadata
-* Add Puppet 8 support
 
 **Breaking Changes**
-* Drop Puppet 6 and earlier support
+* Drop Puppet 6 and earlier support (canihavethisone)
 
 ## Release 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Update changelog and metadata
 
 **Breaking Changes**
-* Drop Puppet 6 and earlier support, add Puppet 7 & 8
+* Drop Puppet 6 and earlier support, add Puppet 8
 
 ## Release 2.2.0
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "iu-aide",
-  "version": "2.2.1",
+  "version": "3.0.0",
   "author": "Kenneth Gyan <kgyan@iu.edu>, Mark Addonizio <maddoni@iu.edu>",
   "summary": "Installs, configures, and manages AIDE (Advanced Intrustion Detection Environment).",
   "license": "BSD-3-Clause",
@@ -54,7 +54,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
Ran unit tests using PDK v3.0.0 with ruby 3.2.2 and Puppet 8.1.0